### PR TITLE
ci: add GitHub Actions workflow for Quarto publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: main
+
+name: Quarto Publish
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,3 +25,6 @@ format:
     css: content/cv.css
     toc: true
     toc-title: "En esta página"
+
+execute: 
+  freeze: auto


### PR DESCRIPTION
Add GitHub Actions workflow to automatically render and publish the Quarto site to gh-pages on pushes to main. Also configure Quarto freeze: auto to avoid re-rendering unchanged documents.